### PR TITLE
Update primary key parsing for findOne

### DIFF
--- a/lib/apiUtil.js
+++ b/lib/apiUtil.js
@@ -686,13 +686,8 @@ var
         pk = req.options.id || (req.options.where && req.options.where.id) || req.param('id') || req.param(pkName);
 
       // Exclude criteria on id field
-      if (!_.isUndefined(pk) && _.isFinite(parseInt(pk, 10))) {
-        pk = parseInt(pk, 10);
-      } else {
-        pk = undefined;
-      }
-
-      return pk;
+        pk = _.isPlainObject(pk) ? undefined : pk;
+        return pk;
     },
 
     /**


### PR DESCRIPTION
Updated to use Sails blueprints default primary key method